### PR TITLE
HTML bug - removed extra closing div tag

### DIFF
--- a/templates/modular/text.html.twig
+++ b/templates/modular/text.html.twig
@@ -13,5 +13,4 @@
     </div>
     {% endfor %}
   </div>
-</div>
 </section>


### PR DESCRIPTION
Extra closing div tag is breaking html when you inspect, showing modules News and Signup outside of #content div.
![image](https://user-images.githubusercontent.com/3932870/104094953-65b61000-5294-11eb-9ebf-317b5d36fc41.png)
